### PR TITLE
Fixes bug, highlights a projects first palette when selected

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -47,7 +47,15 @@ class App extends Component {
     this.setState({ projectId: parseInt(e.target.value) });
     let currentProjectId = parseInt(e.target.value);
     let currentPalette = this.state.palettes.find(palette => palette.projectId === currentProjectId)
-    this.updatePalette(e, currentPalette);
+    if (currentPalette) {
+      let passEvent = {
+        target: {
+          innerText: currentPalette.name,
+          value: currentPalette.id
+        }
+      }
+      this.updatePalette(passEvent, currentPalette);
+    }
   }
 
   updatePalette = (e, palette) => {


### PR DESCRIPTION
#### What's this PR do?
When a project is selected, if it has any palettes it will highlight the first palette.
This wasn't working as intended and was only highlighting the first project's palette.
Now works properly.
#### Where should the reviewer start?
in App.js  at updateProject.  It now passes a passEvent down to its first child.
#### How should this be manually tested?
run in the browser